### PR TITLE
Catch path.length

### DIFF
--- a/src/PairLibrary.sol
+++ b/src/PairLibrary.sol
@@ -109,12 +109,13 @@ library PairLibrary {
         internal
         view
         returns (uint256[] memory amounts)
-    {
-        if (path.length < 2) revert ErrInvalidPath();
-        amounts = new uint256[](path.length);
+    {   
+        uint256 pathLength = path.length;
+        if (pathLength < 2) revert ErrInvalidPath();
+        amounts = new uint256[](pathLength);
         amounts[0] = amountIn;
         unchecked {
-            uint256 pathLengthSub1 = path.length - 1;
+            uint256 pathLengthSub1 = pathLength - 1;
             for (uint256 i; i < pathLengthSub1; ++i) {
                 (uint256 reserveIn, uint256 reserveOut) = getReserves(factory, path[i], path[i + 1]);
                 amounts[i + 1] = getAmountOut(amounts[i], reserveIn, reserveOut);
@@ -127,13 +128,14 @@ library PairLibrary {
         internal
         view
         returns (uint256[] memory amounts, address[] memory pairs)
-    {
-        if (path.length < 2) revert ErrInvalidPath();
-        amounts = new uint256[](path.length);
-        pairs = new address[](path.length);
+    {   
+        uint256 pathLength = path.length;
+        if (pathLength < 2) revert ErrInvalidPath();
+        amounts = new uint256[](pathLength);
+        pairs = new address[](pathLength);
         amounts[0] = amountIn;
         unchecked {
-            uint256 pathLengthSub1 = path.length - 1;
+            uint256 pathLengthSub1 = pathLength - 1;
             pairs[0] = pairFor(factory, path[0], path[1]);
             for (uint256 i; i < pathLengthSub1; ++i) {
                 (uint256 reserveIn, uint256 reserveOut, address pair) =
@@ -150,12 +152,13 @@ library PairLibrary {
         view
         returns (uint256[] memory amounts)
     {
-        if (path.length < 2) revert ErrInvalidPath();
-        amounts = new uint256[](path.length);
+        uint256 pathLength = path.length;
+        if (pathLength < 2) revert ErrInvalidPath();
+        amounts = new uint256[](pathLength);
         unchecked {
             amounts[amounts.length - 1] = amountOut;
-            address pair = pairFor(factory, path[path.length - 2], path[path.length - 1]);
-            for (uint256 i = path.length - 1; i > 0; --i) {
+            address pair = pairFor(factory, path[pathLength - 2], path[pathLength - 1]);
+            for (uint256 i = pathLength - 1; i > 0; --i) {
                 (uint256 reserveIn, uint256 reserveOut) = getReserves(factory, path[i - 1], path[i]);
                 amounts[i - 1] = getAmountIn(amounts[i], reserveIn, reserveOut);
             }


### PR DESCRIPTION
Run with: `forge test --gas-report --fuzz-seed 10`

```diff
 | lib/forge-std/src/mocks/MockERC20.sol:MockERC20 contract |                 |       |        |       |         |
 |----------------------------------------------------------|-----------------|-------|--------|-------|---------|
 | Deployment Cost                                          | Deployment Size |       |        |       |         |
 | 766624                                                   | 4368            |       |        |       |         |
 | Function Name                                            | min             | avg   | median | max   | # calls |
-| approve                                                  | 46118           | 46269 | 46226  | 46490 | 800     |
+| approve                                                  | 46118           | 46265 | 46214  | 46490 | 800     |
-| balanceOf                                                | 542             | 1140  | 542    | 2542  | 13524   |
+| balanceOf                                                | 542             | 1141  | 542    | 2542  | 13518   |
-| mint                                                     | 24235           | 62655 | 68280  | 68640 | 5860    |
+| mint                                                     | 24235           | 62654 | 68280  | 68640 | 5860    |
 | totalSupply                                              | 2363            | 2363  | 2363   | 2363  | 6       |
 | transfer                                                 | 28545           | 50622 | 51317  | 51353 | 1154    |
 
 
 | lib/nativo/src/Nativo.sol:Nativo contract |                 |       |        |       |         |
 |-------------------------------------------|-----------------|-------|--------|-------|---------|
 | Deployment Cost                           | Deployment Size |       |        |       |         |
-| 1723196                                   | 8812            |       |        |       |         |
+| 1688558                                   | 8812            |       |        |       |         |
 | Function Name                             | min             | avg   | median | max   | # calls |
 | balanceOf                                 | 560             | 1314  | 560    | 2560  | 4105    |
 | deposit                                   | 45222           | 45222 | 45222  | 45222 | 9       |
-| transfer                                  | 28448           | 50984 | 51232  | 51316 | 770     |
+| transfer                                  | 28448           | 50954 | 51232  | 51316 | 770     |
 
 
 | lib/solady/src/tokens/WETH.sol:WETH contract |                 |       |        |       |         |
 |----------------------------------------------|-----------------|-------|--------|-------|---------|
 | Deployment Cost                              | Deployment Size |       |        |       |         |
 | 603007                                       | 2579            |       |        |       |         |
 | Function Name                                | min             | avg   | median | max   | # calls |
-| approve                                      | 45987           | 46137 | 46095  | 46359 | 528     |
+| approve                                      | 45999           | 46140 | 46107  | 46359 | 528     |
 | balanceOf                                    | 545             | 1879  | 2545   | 2545  | 4617    |
 | deposit                                      | 68804           | 68804 | 68804  | 68804 | 1545    |
 | transfer                                     | 28376           | 51061 | 51088  | 51244 | 2306    |
 
 
 | src/Factory.sol:LatamswapFactory contract |                 |         |         |         |         |
 |-------------------------------------------|-----------------|---------|---------|---------|---------|
 | Deployment Cost                           | Deployment Size |         |         |         |         |
-| 2561994                                   | 18142           |         |         |         |         |
+| 3833452                                   | 18142           |         |         |         |         |
 | Function Name                             | min             | avg     | median  | max     | # calls |
 | allPairs                                  | 604             | 1185    | 604     | 2347    | 6       |
 | allPairsLength                            | 348             | 348     | 348     | 348     | 1       |
 | createPair                                | 22237           | 1852833 | 1866687 | 1883331 | 644     |
 | getPair                                   | 782             | 2445    | 2782    | 2782    | 3080    |
 | withdraw(address,address)                 | 24415           | 38588   | 38588   | 52762   | 2       |
 | withdraw(address,address,uint256)         | 24554           | 40763   | 40763   | 56972   | 2       |
 
 
 | src/PairV2-NATIVO-WETH.sol:PairV2Native contract |                 |       |        |        |         |
 |--------------------------------------------------|-----------------|-------|--------|--------|---------|
 | Deployment Cost                                  | Deployment Size |       |        |        |         |
 | 1233053                                          | 5828            |       |        |        |         |
 | Function Name                                    | min             | avg   | median | max    | # calls |
 | burn                                             | 21894           | 21894 | 21894  | 21894  | 1       |
 | getReserves                                      | 2453            | 2453  | 2453   | 2453   | 2       |
 | mint                                             | 21890           | 21890 | 21890  | 21890  | 257     |
-| skim                                             | 47216           | 80216 | 80820  | 80820  | 513     |
+| skim                                             | 47216           | 80171 | 80820  | 80820  | 513     |
-| swap                                             | 60563           | 78979 | 97073  | 111124 | 1026    |
+| swap                                             | 60563           | 78980 | 97073  | 111124 | 1026    |
 | sync                                             | 26395           | 26395 | 26395  | 26395  | 1       |
 | totalSupply                                      | 296             | 296   | 296    | 296    | 1       |
 
 
 | src/PairV2.sol:PairV2 contract |                 |        |        |        |         |
 |--------------------------------|-----------------|--------|--------|--------|---------|
 | Deployment Cost                | Deployment Size |        |        |        |         |
 | 1860251                        | 8853            |        |        |        |         |
 | Function Name                  | min             | avg    | median | max    | # calls |
-| DOMAIN_SEPARATOR               | 628             | 628    | 628    | 628    | 238     |
+| DOMAIN_SEPARATOR               | 628             | 628    | 628    | 628    | 245     |
 | MINIMUM_LIQUIDITY              | 284             | 284    | 284    | 284    | 32      |
-| balanceOf                      | 568             | 1914   | 2568   | 2568   | 1386    |
+| balanceOf                      | 568             | 1894   | 2568   | 2568   | 1389    |
 | burn                           | 47266           | 79894  | 81117  | 122975 | 8       |
 | decimals                       | 245             | 245    | 245    | 245    | 1       |
-| getReserves                    | 571             | 1968   | 2571   | 2571   | 6851    |
+| getReserves                    | 571             | 1965   | 2571   | 2571   | 6850    |
 | kLast                          | 363             | 1363   | 1363   | 2363   | 2       |
 | mint                           | 61754           | 167366 | 174298 | 174298 | 292     |
 | name                           | 627             | 627    | 627    | 627    | 1       |
 | price0CumulativeLast           | 362             | 584    | 362    | 2362   | 9       |
 | price1CumulativeLast           | 384             | 606    | 384    | 2384   | 9       |
 | skim                           | 49313           | 66765  | 65541  | 85441  | 3       |
 | swap                           | 30037           | 49545  | 52726  | 67794  | 34      |
 | symbol                         | 566             | 566    | 566    | 566    | 1       |
 | sync                           | 38373           | 78122  | 78205  | 85684  | 2059    |
 | token0                         | 284             | 284    | 284    | 284    | 256     |
 | token1                         | 327             | 327    | 327    | 327    | 256     |
-| totalSupply                    | 393             | 1544   | 2393   | 2393   | 1621    |
+| totalSupply                    | 393             | 1527   | 2393   | 2393   | 1624    |
 | transfer                       | 46406           | 46408  | 46406  | 46418  | 6       |
 
 
 | src/Router.sol:LatamswapRouter contract                   |                 |        |        |         |         |
 |-----------------------------------------------------------|-----------------|--------|--------|---------|---------|
 | Deployment Cost                                           | Deployment Size |        |        |         |         |
-| 3332780                                                   | 15831           |        |        |         |         |
+| 3333604                                                   | 15835           |        |        |         |         |
 | Function Name                                             | min             | avg    | median | max     | # calls |
-| addLiquidity                                              | 135280          | 426646 | 235178 | 2087128 | 1026    |
+| addLiquidity                                              | 135292          | 428319 | 235178 | 2087128 | 1026    |
-| addLiquidityETH                                           | 43556           | 328864 | 241795 | 2085512 | 1536    |
+| addLiquidityETH                                           | 43556           | 327570 | 241795 | 2085512 | 1536    |
 | addLiquidityTokenA                                        | 30970           | 104649 | 142349 | 159478  | 5       |
-| removeLiquidity                                           | 30057           | 30091  | 30069  | 30165   | 95      |
+| removeLiquidity                                           | 30057           | 30089  | 30069  | 30165   | 99      |
-| removeLiquidityETH                                        | 29525           | 29565  | 29537  | 29681   | 145     |
+| removeLiquidityETH                                        | 29525           | 29564  | 29537  | 29681   | 141     |
-| removeLiquidityETHSupportingFeeOnTransferTokens           | 29587           | 29629  | 29599  | 29743   | 138     |
+| removeLiquidityETHSupportingFeeOnTransferTokens           | 29587           | 29628  | 29599  | 29743   | 134     |
-| removeLiquidityETHWithPermitSupportingFeeOnTransferTokens | 39005           | 39047  | 39017  | 39161   | 138     |
+| removeLiquidityETHWithPermitSupportingFeeOnTransferTokens | 39005           | 39046  | 39017  | 39161   | 134     |
-| removeLiquidityWithPermit                                 | 39466           | 39678  | 39724  | 39850   | 100     |
+| removeLiquidityWithPermit                                 | 39478           | 39676  | 39850  | 39850   | 111     |
 | swapExactETHForTokens                                     | 0               | 0      | 0      | 0       | 512     |
 | swapExactETHForTokensSupportingFeeOnTransferTokens        | 0               | 0      | 0      | 0       | 256     |
 | swapExactTokensForETH                                     | 24692           | 24692  | 24692  | 24692   | 256     |
-| swapExactTokensForETHSupportingFeeOnTransferTokens        | 24316           | 24459  | 24412  | 24688   | 256     |
+| swapExactTokensForETHSupportingFeeOnTransferTokens        | 24328           | 24462  | 24418  | 24688   | 256     |
-| swapExactTokensForTokens                                  | 33355           | 74450  | 78297  | 78441   | 256     |
+| swapExactTokensForTokens                                  | 33358           | 74453  | 78302  | 78446   | 256     |
-| swapExactTokensForTokensSupportingFeeOnTransferTokens     | 57276           | 84265  | 86760  | 86904   | 256     |
+| swapExactTokensForTokensSupportingFeeOnTransferTokens     | 57276           | 84245  | 86760  | 86904   | 256     |
 | swapTokensForExactETH                                     | 24670           | 24670  | 24670  | 24670   | 256     |
 
 
 | test/DeflatingERC20.sol:DeflatingERC20 contract |                 |       |        |       |         |
 |-------------------------------------------------|-----------------|-------|--------|-------|---------|
 | Deployment Cost                                 | Deployment Size |       |        |       |         |
 | 643659                                          | 3113            |       |        |       |         |
 | Function Name                                   | min             | avg   | median | max   | # calls |
-| approve                                         | 46145           | 46301 | 46265  | 46517 | 272     |
+| approve                                         | 46157           | 46304 | 46271  | 46517 | 272     |
-| balanceOf                                       | 564             | 1281  | 564    | 2564  | 2855    |
+| balanceOf                                       | 564             | 1282  | 564    | 2564  | 2851    |
-| mint                                            | 24160           | 61909 | 68356  | 68716 | 2304    |
+| mint                                            | 24160           | 61864 | 68356  | 68716 | 2304    |
 
 
 | test/MockToken.sol:MockToken contract |                 |       |        |       |         |
 |---------------------------------------|-----------------|-------|--------|-------|---------|
 | Deployment Cost                       | Deployment Size |       |        |       |         |
 | 731261                                | 3708            |       |        |       |         |
 | Function Name                         | min             | avg   | median | max   | # calls |
 | approve                               | 46467           | 46467 | 46467  | 46467 | 8       |
 | balanceOf                             | 564             | 578   | 564    | 2564  | 1618    |
 | mint                                  | 68180           | 68180 | 68180  | 68180 | 2       |
 
 
 | test/Pair.fuzz.t.sol:MockFactory contract |                 |       |        |       |         |
 |-------------------------------------------|-----------------|-------|--------|-------|---------|
 | Deployment Cost                           | Deployment Size |       |        |       |         |
 | 131420                                    | 426             |       |        |       |         |
 | Function Name                             | min             | avg   | median | max   | # calls |
 | setFeeTo                                  | 23956           | 23956 | 23956  | 23956 | 1       |
 
 
 | test/Pair.fuzz.t.sol:MockUser contract |                 |       |        |       |         |
 |----------------------------------------|-----------------|-------|--------|-------|---------|
 | Deployment Cost                        | Deployment Size |       |        |       |         |
 | 276903                                 | 1068            |       |        |       |         |
 | Function Name                          | min             | avg   | median | max   | # calls |
-| addLiquidity                           | 28413           | 45303 | 61023  | 61635 | 512     |
+| addLiquidity                           | 28401           | 45937 | 61029  | 61635 | 512     |
 
 
 | test/helper/BasePairTest.sol:MockFactory contract |                 |       |        |       |         |
 |---------------------------------------------------|-----------------|-------|--------|-------|---------|
 | Deployment Cost                                   | Deployment Size |       |        |       |         |
-| 131420                                            | 426             |       |        |       |         |
+| 131408                                            | 426             |       |        |       |         |
 | Function Name                                     | min             | avg   | median | max   | # calls |
 | feeTo                                             | 2303            | 2303  | 2303   | 2303  | 288     |
 | setFeeTo                                          | 23944           | 23952 | 23956  | 23956 | 57      |
 
 
 | test/helper/BasePairTest.sol:MockUser contract |                 |        |        |        |         |
 |------------------------------------------------|-----------------|--------|--------|--------|---------|
 | Deployment Cost                                | Deployment Size |        |        |        |         |
 | 276903                                         | 1068            |        |        |        |         |
 | Function Name                                  | min             | avg    | median | max    | # calls |
 | addLiquidity                                   | 60430           | 109882 | 106049 | 131900 | 10      |
 | removeLiquidity                                | 93940           | 106156 | 106156 | 118373 | 2       |
 ```